### PR TITLE
doc/contrib.html: update links, mailing lists and link to 1.3 release note.

### DIFF
--- a/doc/contrib.html
+++ b/doc/contrib.html
@@ -4,7 +4,7 @@
 }-->
 
 <!--
-本ドキュメントは以下のドキュメントを翻訳しています: https://code.google.com/p/go/source/browse/doc/contrib.html?r=3d1fd5df05ddd05ec47ae860876027561ddde03c
+本ドキュメントは以下のドキュメントを翻訳しています: https://code.google.com/p/go/source/browse/doc/contrib.html?r=de014d3583bbb3fa4056f3e40381fcff7b9a9738
 -->
 
 <img class="gopher" src="/doc/gopher/project.png" />
@@ -41,14 +41,19 @@ Goのユーザであれば、<a href="http://groups.google.com/group/golang-anno
 Go 1へコードを更新するためのガイドです。
 </p>
 
-<h4 id="go1.1notes"><a href="/doc/go1.1">Go 1.1 リリースノート</a></h4>
+<h4 id="release notes"><a href="/doc/go1.1">Go 1.1 リリースノート</a></h4>
+<!--
+<p>
+A list of significant changes in Go 1.1, with instructions for updating
+your code where necessary.
+Each point release includes a similar document appropriate for that
+release: <a href="/doc/go1.2">Go 1.2</a>, <a href="/doc/go1.3">Go 1.3</a>,
+and so on.
+</p>
+-->
 <p>
 Go 1.1の重要な変更点と、コードの更新方法などがあります。
-</p>
-
-<h4 id="go1.2notes"><a href="/doc/go1.2">Go 1.2 リリースノート</a></h4>
-<p>
-Go 1.2の重要な変更点と、コードの更新方法などがあります。
+リリースの各ポイントは<a href="/doc/go1.2">Go 1.2</a>, <a href="/doc/go1.3">Go 1.3</a>などの適切なドキュメントに記載しています。
 </p>
 
 <h3 id="go1compat"><a href="/doc/go1compat">Go 1 and the Future of Go Programs</a></h3>
@@ -64,19 +69,32 @@ Go 1の定義と、Go 1が成長する過程で期待できる後方互換性の
 Goのソースコードは<a href="https://code.google.com/p/go/source">リポジトリ</a>からチェックアウトできます。
 </p>
 
-<h3 id="golang-dev"><a href="http://groups.google.com/group/golang-dev">開発者用のメーリングリスト</a></h3>
+<h3 id="golang-dev"><a href="https://groups.google.com/group/golang-dev">開発者</a> と
+<a href="https://groups.google.com/group/golang-codereviews">コードレビュー用メーリングリスト</a></h3>
+<!--
+<p>The <a href="https://groups.google.com/group/golang-dev">golang-dev</a>
+mailing list is for discussing code changes to the Go project.
+The <a href="https://groups.google.com/group/golang-codereviews">golang-codereviews</a>
+mailing list is for actual reviewing of the code changes (CLs).</p>
+-->
 <p>
-<a href="http://groups.google.com/group/golang-dev">golang-dev</a>メーリングリストはGoプロジェクトの議論やコードレビューをしています。
+<a href="https://groups.google.com/group/golang-dev">golang-dev</a>
+メーリングリストは、Goプロジェクトへのコード修正について議論しています。
+<a href="https://groups.google.com/group/golang-codereviews">golang-codereviews</a>
+メーリングリストは、コード修正(CLs)のレビューを実施しています。
 </p>
 <p>
 Goプログラミングの一般的な議論については、
-<a href="http://groups.google.com/group/golang-nuts">golang-nuts</a>を利用してください。
+<a href="https://groups.google.com/group/golang-nuts">golang-nuts</a>を利用してください。
 </p>
 
-<h3 id="golang-checkins"><a href="http://groups.google.com/group/golang-checkins">チェックイン通知のメーリングリスト</a></h3>
+<h3 id="golang-checkins"><a href="https://groups.google.com/group/golang-checkins">チェックイン通知のメーリングリスト</a></h3>
 <p>
 Goリポジトリへの各チェックイン（push）の概要を受け取るためのメーリングリストです。
 </p>
+
+<h3 id="golang-bugs"><a href="https://groups.google.com/group/golang-bugs">バグ用メーリングリスト</a></h3>
+<p>Goの<a href="http://golang.org/issue">issue tracker</a>の更新状況のメーリングリストです。</p>
 
 <h3 id="build_status"><a href="http://build.golang.org/">ビルドステータス</a></h3>
 <p>
@@ -91,12 +109,12 @@ Goリポジトリへの各チェックイン（push）の概要を受け取る�
 
 <h2 id="howto">支援するには</h2>
 
-<h3><a href="http://code.google.com/p/go/issues">問題(issue)を報告するには</a></h3>
+<h3><a href="https://code.google.com/p/go/issues">問題(issue)を報告するには</a></h3>
 
 <p>
 Goプロジェクトのコードやドキュメント（訳注1）でバグ・ミス・不整合を発見した場合、
-<a href="http://code.google.com/p/go/issues">issue tracker</a>で
-<a href="http://code.google.com/p/go/issues/entry">チケットを登録</a>してください。
+<a href="https://code.google.com/p/go/issues">issue tracker</a>で
+<a href="https://code.google.com/p/go/issues/entry">チケットを登録</a>してください。
 （もちろん、新しいissueを作成する前に既に登録されていないかチェックしておいてください。）
 </p>
 
@@ -118,8 +136,8 @@ Goはオープンソースプロジェクトで、コミュニティからの貢
 <a href="/doc/contribute.html">contribution guidelines</a>を読んでください。
 </p>
 <p>
-あなたの興味のあるopenになっているissueを<a href="http://code.google.com/p/go/issues">issue tracker</a>でチェックしてみてください。
-<a href="http://code.google.com/p/go/issues/list?q=status=HelpWanted">HelpWanted</a>とラベルされているものは、特に外部の助けを必要としています。
+あなたの興味のあるopenになっているissueを<a href="https://code.google.com/p/go/issues">issue tracker</a>でチェックしてみてください。
+<a href="https://code.google.com/p/go/issues/list?q=status=HelpWanted">HelpWanted</a>とラベルされているものは、特に外部の助けを必要としています。
 </p>
 
 <h3><a href="https://github.com/gophersjp/go">Goの日本語訳へ貢献するには</a></h3>


### PR DESCRIPTION
更新しました

https://code.google.com/p/go/source/browse/doc/contrib.html?r=de014d3583bbb3fa4056f3e40381fcff7b9a9738
