### PR TITLE
doc/install.html: update to tip version 951cc5f6d52ff1dc2bb9d8e6b2fb98fe1699a34f

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -4,13 +4,13 @@
 }-->
 
 <!--
-本ドキュメントは以下のドキュメントを翻訳しています: https://code.google.com/p/go/source/browse/doc/install.html?r=89509169b5a958382941ad1935f5bd4ece3ebb2e
+本ドキュメントは以下のドキュメントを翻訳しています: https://code.google.com/p/go/source/browse/doc/install.html?r=951cc5f6d52ff1dc2bb9d8e6b2fb98fe1699a34f
 -->
 
 <h2 id="download">Goディストリビューションのダウンロード</h2>
 
 <p>
-<a href="https://code.google.com/p/go/wiki/Downloads?tm=2" id="start" class="download" target="_blank">
+<a href="http://golang.org/dl/" id="start" class="download" target="_blank">
 <span class="big">Download Go</span>
 <span class="desc">クリックしてダウンロードページに移動します</span>
 </a>
@@ -34,9 +34,9 @@
 
 <table class="codetable" frame="border" summary="requirements">
 <tr>
-<th align="middle">オペレーティングシステム</th>
-<th align="middle">アーキテクチャ</th>
-<th align="middle">備考</th>
+<th align="center">オペレーティングシステム</th>
+<th align="center">アーキテクチャ</th>
+<th align="center">備考</th>
 </tr>
 <tr><td colspan="3"><hr></td></tr>
 <tr><td>FreeBSD 8以降</td> <td>amd64, 386, arm</td> <td>Debian GNU/kFreeBSDはサポートなし　FreeBSD/ARMはFreeBSD 10以降</td></tr>
@@ -190,7 +190,7 @@ hello, world
 </p>
 
 <p>
-<a href="/doc/code.html" class="download" id="start">
+<a href="/doc/code.html" class="download" id="writing">
 <span class="big">Goコードの書き方</span>
 <span class="desc">Goツールのセットアップ・利用方法を学びます</span>
 </a>


### PR DESCRIPTION
doc/install.html: fix duplicate id= tag
doc/install.html: fix erroneous HTML
doc: link to new downloads page

https://code.google.com/p/go/source/browse/doc/install.html?r=951cc5f6d52ff1dc2bb9d8e6b2fb98fe1699a34f

注意点として、この変更はrelease-1.3branchとtipで同じものがされていますが、ブランチが違うためリビジョン番号が違います。
こちらはtipにあわせてます。
