### PR TITLE
Fix download link to current URL

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -17,7 +17,7 @@
 </p>
 
 <p>
-<a href="https://code.google.com/p/go/wiki/Downloads?tm=2" target="_blank">
+<a href="https://golang.org/dl/" target="_blank">
 公式バイナリディストリビューション</a>は32ビット（<code>386</code>）、64ビット（<code>amd64</code>）x86プロセッサアーキテクチャのFreeBSD（release 8以降）、Linux、Mac OS X（Snow Leopard以降）、Windowsオペレーティングシステムに対応しています。
 </p>
 
@@ -60,7 +60,7 @@
 <h3 id="tarball">Linux、Mac OS X、FreeBSD tarball</h3>
 
 <p>
-<a href="https://code.google.com/p/go/wiki/Downloads?tm=2">アーカイブをダウンロード</a>し、<code>/usr/local</code>に解凍してGoツリーを<code>/usr/local/go</code>に作成してください。例えば、以下のとおりです。
+<a href="https://golang.org/dl/">アーカイブをダウンロード</a>し、<code>/usr/local</code>に解凍してGoツリーを<code>/usr/local/go</code>に作成してください。例えば、以下のとおりです。
 </p>
 
 <pre>
@@ -105,7 +105,7 @@ export PATH=$PATH:$GOROOT/bin
 <h3 id="osx">Mac OS Xパッケージインストーラ</h3>
 
 <p>
-<a href="https://code.google.com/p/go/wiki/Downloads?tm=2">パッケージファイルをダウンロード</a>し、ファイルを開いてプロンプトにしたがってGoツールをインストールします。パッケージは<code>/usr/local/go</code>にGoディストリビューションをインストールします。
+<a href="https://golang.org/dl/">パッケージファイルをダウンロード</a>し、ファイルを開いてプロンプトにしたがってGoツールをインストールします。パッケージは<code>/usr/local/go</code>にGoディストリビューションをインストールします。
 </p>
 
 <p>
@@ -121,7 +121,7 @@ GoプロジェクトはWindowsユーザのために（<a href="/doc/install/sour
 <h4 id="windows_msi">MSIインストーラ</h4>
 
 <p>
-<a href="https://code.google.com/p/go/wiki/Downloads?tm=2">MSIファイル</a>を開き、プロンプトにしたがってGoツールをインストールしてください。デフォルトでは、<code>c:\Go</code>にGoディストリビューションをインストールします。
+<a href="https://golang.org/dl/">MSIファイル</a>を開き、プロンプトにしたがってGoツールをインストールしてください。デフォルトでは、<code>c:\Go</code>にGoディストリビューションをインストールします。
 </p>
 
 <p>
@@ -131,7 +131,7 @@ GoプロジェクトはWindowsユーザのために（<a href="/doc/install/sour
 <h4 id="windows_zip">zipアーカイブ</h4>
 
 <p>
-<a href="https://code.google.com/p/go/wiki/Downloads?tm=2">zipファイルをダウンロード</a>し、任意のディレクトリに解凍します。（<code>c:\Go</code>をお薦めします。）
+<a href="https://golang.org/dl/">zipファイルをダウンロード</a>し、任意のディレクトリに解凍します。（<code>c:\Go</code>をお薦めします。）
 </p>
 
 <p>


### PR DESCRIPTION
ダウンロード先のリンクが古く、GithubのGoのトップページに飛ばされてしまうのを修正
